### PR TITLE
Small Adjustments to Site

### DIFF
--- a/src/components/layout/SiteLayout.tsx
+++ b/src/components/layout/SiteLayout.tsx
@@ -43,23 +43,14 @@ const NavBar = () => {
         <NavLink href={"/"} color={Color.SpruceLight}>
           Conference Home
         </NavLink>
-        <NavLink href={"/2021/rfp"} color={Color.SpruceLight}>
-          Request for Proposals
-        </NavLink>
-        <NavLink
-          href={"/2021/call-for-presentations"}
-          color={Color.SpruceLight}
-        >
-          Call for Posters
+        <NavLink href={"/2021/schedule"} color={Color.SpruceLight}>
+          Schedule
         </NavLink>
         <NavLink href={"/2021/hackathon"} color={Color.SpruceLight}>
           Hackathon
         </NavLink>
-        <NavLink href={"/2021/schedule"} color={Color.SpruceLight}>
-          Schedule
-        </NavLink>
         <NavLink href={"/2021/sponsors"} color={Color.SpruceLight}>
-          Sponsors
+          Expo
         </NavLink>
         <NavLink href={"/2021/awards"} color={Color.SpruceLight}>
           Awards

--- a/src/pages/2021/sponsors.mdx
+++ b/src/pages/2021/sponsors.mdx
@@ -1,3 +1,4 @@
+import { CTAButton } from "../../components/button/CTAButton";
 import { SiteLayout } from "../../components/layout/SiteLayout";
 
 <SiteLayout title="Schedule">
@@ -9,6 +10,10 @@ import { SiteLayout } from "../../components/layout/SiteLayout";
 </div>
 
 [Current sponsors? Click here for 2021 conference logistics.](sponsorlogistics)
+
+<div class="text-center my-4">
+    <CTAButton onClick="https://app.brazenconnect.com/app/events/VgxjR/">Sign up for the Expo</CTAButton>
+</div>
 
 ## Career expo search
     

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -35,13 +35,12 @@ import { SiteLayout } from "../components/layout/SiteLayout";
         <p>
             We have a dedicated Career and Graduate School Expo, allowing you to find the best opportunities from organizations and schools that will accept and support you.
             Closer to the start of the conference, we'll be providing information about what opportunities are available from each sponsor.
-            We'll have professional development virtual events before the expo to help you get ready and make the best impression
         </p>
         <p>
-            If you are representing an organization that would like to exhibit at our expo, click the button below for information about the sign up process and the benefits of exhibiting at our conference.
+            Finish your career expo profile on Brazen and start looking at what organizations will be at the Expo.
         </p>
         <div class="text-center my-4">
-            <CTAButton onClick="https://www.ostem.org/page/sponsorship-opportunities">Exhibitor Information</CTAButton>
+            <CTAButton onClick="https://app.brazenconnect.com/app/events/VgxjR/">Sign up for the Expo</CTAButton>
         </div>
     </div>
     <div class="rounded-r md:col-span-2 tint tint-light"><img class="object-cover w-full h-full rounded-r" src="/images/oSTEM.2019.0111.jpg" alt=""/></div>


### PR DESCRIPTION
This PR pulls together some small adjustments as we near the conference. This is mostly ensuring that the relevant information isn't crowded out by no longer relevant information.
- Updated main page to go to the Expo event page
- Removed Requests for Proposals and Call for Posters from the sidebar
- Renames "Sponsors" tab to "Expo"
- Adds a Call to Action button on the Sponsors/Expo page for people to sign up