### PR TITLE
Update faq.mdx

### DIFF
--- a/src/pages/2022/faq.mdx
+++ b/src/pages/2022/faq.mdx
@@ -29,22 +29,10 @@ oSTEM will not be hosting a hackathon at this year’s conference. Instead, we w
 
 ### How do I register for the conference?
 
-Registration for the conference is now open! Visit our [Conference Registration Page](https://conference.ostem.org/2022/registration) for more information.
+Registration for the conference is now open! Visit our [Conference Registration Page](https://conference.ostem.org/2022/registration) for pricing and more information.
   
 oSTEM Members receive an automatic discount. Not an [oSTEM member](https://ostem.org/page/how-to-join-ostem)? Click here to [join now](https://ostem.org/page/how-to-join-ostem). All tickets purchased on or after September 1 will cost the following:
 
-### How much does registration cost?
-  
- - Students
-   - $150 member
-   - $225 non-member
- - Expo Only
-   - $75 1-day ticket
-   - $100 2-day ticket
- - Professional
-   - $425 member
-   - $525 non-member
-  
 ### What does conference registration cover?
 
 - The Student and Professional tickets are both all-access passes to conference programming, events, and meals.


### PR DESCRIPTION
Removed pricing on FAQ and added "pricing" to the statement "Visit our [Conference Registration Page](https://conference.ostem.org/2022/registration) for pricing and more information." Hoping this change cuts down on content on this page as we add more information.