### PR TITLE
Add links to detailed agenda

### DIFF
--- a/src/components/layout/SiteLayout.tsx
+++ b/src/components/layout/SiteLayout.tsx
@@ -112,7 +112,13 @@ const NavBarLinks = () => {
         Conference Home
       </NavLink>
       <NavLink href={"/2022/schedule"} color={Color.AntiqueTeal}>
-        Schedule
+        High Level Schedule
+      </NavLink>
+      <NavLink
+        href="https://whova.com/embedded/event/tTwmdLA%40Va-l9L5Fq6HAx4EtI7njz4P25IpFWfGrgOM%3D/?refer=undefined&day=0"
+        color={Color.AntiqueTeal}
+      >
+        Detailed Agenda
       </NavLink>
       <NavLink href={"/2022/registration"} color={Color.AntiqueTeal}>
         Registration

--- a/src/pages/2022/schedule.mdx
+++ b/src/pages/2022/schedule.mdx
@@ -1,4 +1,5 @@
 import { SiteLayout } from "../../components/layout/SiteLayout";
+import { CTAButton } from "../../components/button/CTAButton";
 
 <SiteLayout title="Schedule">
 
@@ -8,7 +9,10 @@ import { SiteLayout } from "../../components/layout/SiteLayout";
     </p>
 </div>
 
-All times listed are in Eastern Time (ET). Please note that this is a high-level schedule and a more detailed schedule will be made available closer to the conference.
+All times listed are in Eastern Time (ET). Please note that this is a high-level schedule. The detailed agenda can be viewed at the link below.
+<div className="text-center">
+<CTAButton onClick="https://whova.com/embedded/event/tTwmdLA%40Va-l9L5Fq6HAx4EtI7njz4P25IpFWfGrgOM%3D/?refer=undefined&day=0" backgroundColor="skyblue">View Detailed Agenda</CTAButton>
+</div>
 
 ## Thursday, November 10
 - **3:00 PM - 7:00 PM**   Registration Desk Open


### PR DESCRIPTION
Adds a sidebar link and a button on the detailed agenda page.

Eventually I'd like to see if I can do a properly embedded page, but that's going to take a bit more time and not in this PR.